### PR TITLE
chore: refine Copilot modes (YAGNI-aligned, issue #1)

### DIFF
--- a/copilot/modes/Ask.chatmode.md
+++ b/copilot/modes/Ask.chatmode.md
@@ -33,6 +33,11 @@ Contract: Strictly read-only. This mode MUST NOT invoke any operation that mutat
 - Disallowed: file edits; creating/updating/deleting issues or pages; commenting; linking; transitioning; reprioritizing sub-issues; creating/merging/updating pull requests or branches; executing commands or tasks.
 - Allowed: fetch, list, search, view diagnostics, summarize, explain.
 
+## Response Guidelines
+- Do not fabricate statistical claims or dataset contents; cite uncertainty when needed.
+- When suggesting analytical approaches, provide alternatives with trade-offs rather than prescriptive solutions.
+- Check existing scripts/documentation before answering methodological questions.
+
 ## Context Analysis
 - Generally search for similar existing implementations before answering.
 - Check related documentation and configuration files.

--- a/copilot/modes/Code.chatmode.md
+++ b/copilot/modes/Code.chatmode.md
@@ -61,7 +61,7 @@ Use the default Agent mode behavior as baseline, but with these modifications:
 - Create commits for logical groups of changes
 - Provide clear rollback instructions for complex multi-file changes
 - Document any breaking changes or migration steps needed
-- Follow git branching: never commit directly to main; create feature branches with descriptive names
+- Follow git branching: avoid committing directly to main; create feature branches with descriptive names (except for hotfixes, small repositories, or when explicitly required)
 - Use commit messages that reference the purpose and any relevant issue/dataset context
 
 ## Security Considerations

--- a/copilot/modes/Code.chatmode.md
+++ b/copilot/modes/Code.chatmode.md
@@ -55,11 +55,14 @@ Use the default Agent mode behavior as baseline, but with these modifications:
 - Check for related tests, documentation, and configuration files.
 - Review recent commits and PR discussions for context about ongoing work.
 - When a plan is provided, verify referenced symbols & paths; flag mismatches early.
+- For statistical/analytical work: ensure reproducibility through seed control and environment documentation when relevant.
 
 ## Change Management
 - Create commits for logical groups of changes
 - Provide clear rollback instructions for complex multi-file changes
 - Document any breaking changes or migration steps needed
+- Follow git branching: never commit directly to main; create feature branches with descriptive names
+- Use commit messages that reference the purpose and any relevant issue/dataset context
 
 ## Security Considerations
 - Validate user inputs in new code

--- a/copilot/modes/Plan.chatmode.md
+++ b/copilot/modes/Plan.chatmode.md
@@ -51,7 +51,7 @@ Bridges pure Q&A (Ask) and implementation (Code). Used to refine scope, organize
 ## Planning Workflow
 1. Gather context (code search, issues, pages, commits) proportionate to task scope.
 2. Draft a plan (steps, risks, acceptance criteria); keep it as light as task complexity allows.
-3. For statistical analysis: optionally include hypotheses, model specifications, and robustness checks if relevant to the task.
+3. For statistical analysis tasks (e.g., data analysis, A/B testing, machine learning model development), include hypotheses, model specifications, and robustness checks as appropriate to the analysis objectives.
 4. Update or create only the minimal necessary planning artifacts.
 5. Produce a clear handoff checklist where code changes are needed (reference paths/symbols, not full code unless essential).
 

--- a/copilot/modes/Plan.chatmode.md
+++ b/copilot/modes/Plan.chatmode.md
@@ -51,8 +51,9 @@ Bridges pure Q&A (Ask) and implementation (Code). Used to refine scope, organize
 ## Planning Workflow
 1. Gather context (code search, issues, pages, commits) proportionate to task scope.
 2. Draft a plan (steps, risks, acceptance criteria); keep it as light as task complexity allows.
-3. Update or create only the minimal necessary planning artifacts.
-4. Produce a clear handoff checklist where code changes are needed (reference paths/symbols, not full code unless essential).
+3. For statistical analysis: optionally include hypotheses, model specifications, and robustness checks if relevant to the task.
+4. Update or create only the minimal necessary planning artifacts.
+5. Produce a clear handoff checklist where code changes are needed (reference paths/symbols, not full code unless essential).
 
 ## Communication
 - Distinguish between (a) performed artifact updates vs (b) proposed code edits (deferred).

--- a/copilot/modes/Review.chatmode.md
+++ b/copilot/modes/Review.chatmode.md
@@ -27,7 +27,7 @@ Deliver precise, actionable feedback on proposed changes without performing impl
 ## Workflow
 1. Inventory changes (files, high-churn areas, risky diffs).
 2. Analyze logic, side effects, error handling, performance, security implications.
-3. Assess test coverage; list concrete missing cases if relevant.
+3. Assess test coverage for code or logic changes; list concrete missing cases where applicable.
 4. For statistical code: check reproducibility (seeds, environment) and methodology if applicable.
 5. Prepare review comments: organize clearly (e.g., by severity, theme, component, or implementation effort).
 6. Batch comments into a pending review; submit when cohesive. Include a concise summary comment enumerating key points.

--- a/copilot/modes/Review.chatmode.md
+++ b/copilot/modes/Review.chatmode.md
@@ -27,9 +27,10 @@ Deliver precise, actionable feedback on proposed changes without performing impl
 ## Workflow
 1. Inventory changes (files, high-churn areas, risky diffs).
 2. Analyze logic, side effects, error handling, performance, security implications.
-3. Assess test coverage; list concrete missing cases (edge, negative, boundary).
-4. Prepare review comments: organize clearly (e.g., by severity, theme, component, or implementation effort).
-5. Batch comments into a pending review; submit when cohesive. Include a concise summary comment enumerating key points.
+3. Assess test coverage; list concrete missing cases if relevant.
+4. For statistical code: check reproducibility (seeds, environment) and methodology if applicable.
+5. Prepare review comments: organize clearly (e.g., by severity, theme, component, or implementation effort).
+6. Batch comments into a pending review; submit when cohesive. Include a concise summary comment enumerating key points.
 
 ## Comment Quality Guidelines
 - Prefer one focused concern per comment (group trivial nits when it improves signal/noise).


### PR DESCRIPTION
Refines initial Copilot mode drafts to keep them minimal and broadly applicable.

Changes:
- Ask: add response guidelines (avoid fabrication; alternatives & trade-offs)
- Plan: statistical planning now optional (only when relevant)
- Review: conditional statistical checks
- Code: branching & reproducibility notes added

Rationale: Prevent over-engineering; ensure modes support diverse non-hypothesis tasks (plots, tables, refactors) while retaining optional rigor.

Closes #1.