### PR TITLE
docs: add 2-level TOC to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,24 @@
 
 Centralized documentation for Copilot modes, tool availability, and cross-tool custom instruction usage.
 
+## Table of Contents
+
+- [Repository Structure](#repository-structure)
+- [Modes Overview](#modes-overview)
+- [Tool Availability Matrix](#tool-availability-matrix)
+- [Notes](#notes)
+- [Using `coding_guidelines.txt` Across Tools](#using-coding_guidelinestxt-across-tools)
+	- [GitHub Copilot (Organization-Level)](#github-copilot-organization-level)
+	- [GitHub Copilot (Repository-Level)](#github-copilot-repository-level)
+	- [Warp (User-Level)](#warp-user-level)
+	- [Q (Repository-Level)](#q-repository-level)
+	- [Claude Code (Repository-Level)](#claude-code-repository-level)
+- [Tool Definitions](#tool-definitions)
+	- [Built-In (VS Code / Core)](#built-in-vs-code--core)
+	- [Context7](#context7)
+	- [Atlassian](#atlassian)
+	- [GitHub](#github)
+
 ## Repository Structure
 
 ```


### PR DESCRIPTION
Adds a concise 2-level Table of Contents near the top of the README for easier navigation.

Scope:
- Insert TOC referencing existing level-2 headers plus relevant level-3 subsections under the usage section and tool definitions.

No other content modified.

Validation:
- Markdown renders locally.
- Only README.md changed.

**Transcript of chat with GPT-5 (Code Mode):**

jbearak: Add a 2-level TOC to the top of this README file. 

GitHub Copilot: Creating a new docs branch, adding a 2-level Table of Contents near the top of README.md, then validating repository structure. Applying patch to insert a 2-level Table of Contents near the top of README. 
```


Made changes.


```
Adjusting TOC to only include level 2 headers (and their direct level 3 children where present) and remove non-existent anchors; also correct anchor text referencing existing headers only. 
```


Made changes.


```
Committing the README change and running repository validation scripts. Added a 2-level TOC and opened PR #11 (docs/readme-toc). Let me know if you want any anchor/style tweaks (e.g., remove sub-bullets or adjust Built-In anchor).