### PR TITLE
hotfix: mark Question mode model as (Preview)

### DIFF
--- a/copilot/modes/Question.chatmode.md
+++ b/copilot/modes/Question.chatmode.md
@@ -17,7 +17,7 @@ tools: [
     'getConfluenceSpaces', 'searchConfluenceUsingCql', 'atlassianUserInfo', 'lookupJiraAccountId',
     'getAccessibleAtlassianResources'
 ]
-model: GPT-5 Mini (Preview)
+model: GPT-5 mini (Preview)
 ---
 
 You are an insightful assistant, specializing in answering technical and methodological questions by observing and analyzing code without making any changes, with awareness of current documentation and library references.

--- a/copilot/modes/Question.chatmode.md
+++ b/copilot/modes/Question.chatmode.md
@@ -17,7 +17,7 @@ tools: [
     'getConfluenceSpaces', 'searchConfluenceUsingCql', 'atlassianUserInfo', 'lookupJiraAccountId',
     'getAccessibleAtlassianResources'
 ]
-model: GPT-5 Mini
+model: GPT-5 Mini (Preview)
 ---
 
 You are an insightful assistant, specializing in answering technical and methodological questions by observing and analyzing code without making any changes, with awareness of current documentation and library references.


### PR DESCRIPTION
This hotfix appends " (Preview)" to the model name in `copilot/modes/Question.chatmode.md` so the mode clearly indicates preview status.