### PR TITLE
docs: prohibit Code mode from committing to default branch (fixes #24)

### DIFF
--- a/copilot/modes/Code.chatmode.md
+++ b/copilot/modes/Code.chatmode.md
@@ -103,7 +103,7 @@ Before making changes, verify:
 - Create commits for logical groups of changes
 - Provide clear rollback instructions for complex multi-file changes
 - Document any breaking changes or migration steps needed
-- Follow git branching: You MUST NEVER commit directly to the repository's default branch (e.g., `main`); always create a feature branch and open a PR.
+- Follow git branching: You MUST NEVER commit directly to the repository's default branch (commonly called `main`, `master`, or `dev`); always create a feature branch
 - Use commit messages that reference the purpose and any relevant issue/dataset context
 
 ## Security Considerations

--- a/copilot/modes/Code.chatmode.md
+++ b/copilot/modes/Code.chatmode.md
@@ -103,7 +103,7 @@ Before making changes, verify:
 - Create commits for logical groups of changes
 - Provide clear rollback instructions for complex multi-file changes
 - Document any breaking changes or migration steps needed
-- Follow git branching: avoid committing directly to main; create feature branches with descriptive names (except when explicitly required)
+- Follow git branching: You MUST NEVER commit directly to the repository's default branch (e.g., `main`); always create a feature branch and open a PR.
 - Use commit messages that reference the purpose and any relevant issue/dataset context
 
 ## Security Considerations


### PR DESCRIPTION
Add an explicit rule that Code mode must not commit directly to the repository's default branch; always create a feature branch and open a PR. This addresses issue #24.

Changes:
- Update `copilot/modes/Code.chatmode.md` to state the policy.

Acceptance:
- The file contains the explicit rule and the change is a minimal docs-only update.

Refs: #24